### PR TITLE
Fix merkle tree spec

### DIFF
--- a/core/merkle-tree.md
+++ b/core/merkle-tree.md
@@ -94,12 +94,12 @@ Contents of nodes:
 - `L2 := sha256(concat(0x00, data[2]))`
 - `L3 := sha256(concat(0x00, data[3]))`
 - `L4 := sha256(concat(0x00, data[4]))`
-- `Iα := sha256(concat(0x01, hash(L0), hash(L1)))`
-- `Iβ := sha256(concat(0x01, hash(L2), hash(L3)))`
-- `Iγ := sha256(concat(0x01, hash(L4), hash(L4)))`
-- `Iδ := sha256(concat(0x01, hash(Iα), hash(Iβ)))`
-- `Iε := sha256(concat(0x01, hash(Iγ), hash(Iγ)))`
-- `Iζ := sha256(concat(0x01, hash(Iδ), hash(Iε)))`
+- `Iα := sha256(concat(0x01, L0, L1))`
+- `Iβ := sha256(concat(0x01, L2, L3))`
+- `Iγ := sha256(concat(0x01, L4, L4))`
+- `Iδ := sha256(concat(0x01, Iα, Iβ))`
+- `Iε := sha256(concat(0x01, Iγ, Iγ))`
+- `Iζ := sha256(concat(0x01, Iδ, Iε))`
 
 ### List Equality Check
 


### PR DESCRIPTION
Currently the "contents of nodes" section is incorrect. It shows extra hashing when creating intermediate nodes that is not present in any of the following implementations: 

Solana labs/Anza: https://github.com/anza-xyz/agave/blob/5263c9d61f3af060ac995956120bef11c1bbf182/merkle-tree/src/merkle_tree.rs#L126 

Firedancer: https://github.com/firedancer-io/firedancer/blob/dd041bb992a2d33561dfb30e6ddc6c471d5c6afe/src/ballet/bmtree/fd_wbmtree.c#L102 or https://github.com/firedancer-io/firedancer/blob/dd041bb992a2d33561dfb30e6ddc6c471d5c6afe/src/ballet/bmtree/fd_bmtree.c#L136
